### PR TITLE
Add reference types support to distribution.

### DIFF
--- a/cmd/registry/config-example-with-extensions.yml
+++ b/cmd/registry/config-example-with-extensions.yml
@@ -1,0 +1,35 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /opt/data/registry-root-dir
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3
+# Configuration for extensions. It follows the below schema
+# extensions
+#   namespace:
+#     configuration for the extension and its components in any schema specific to that namespace
+extensions:
+  oci: 
+    ext:
+      - discover # enable the discovery extension
+    artifacts: 
+      - referrers
+  # "distribution" is the namespace
+  distribution:
+    # "registry" is the extension under the namespace
+    registry:
+      # "taghistory" & "manifests" are the components under the extension
+      - taghistory
+      - manifests

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/auth/htpasswd"
 	_ "github.com/distribution/distribution/v3/registry/auth/silly"
 	_ "github.com/distribution/distribution/v3/registry/auth/token"
+	_ "github.com/distribution/distribution/v3/registry/extension/distribution"
+	_ "github.com/distribution/distribution/v3/registry/extension/oci"
 	_ "github.com/distribution/distribution/v3/registry/proxy"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -247,7 +247,13 @@ type Configuration struct {
 			Classes []string `yaml:"classes"`
 		} `yaml:"repository,omitempty"`
 	} `yaml:"policy,omitempty"`
+
+	// Extensions configures options for the distribution extensions
+	Extensions map[string]ExtensionConfig `yaml:"extensions,omitempty"`
 }
+
+// ExtensionConfig is the configuration of an extension namespace. It can comprise of extension and components.
+type ExtensionConfig interface{}
 
 // LogHook is composed of hook Level and Type.
 // After hooks configuration, it can execute the next handling automatically,

--- a/errors.go
+++ b/errors.go
@@ -24,6 +24,10 @@ var ErrUnsupported = errors.New("operation unsupported")
 // manifest but the registry is configured to reject it
 var ErrSchemaV1Unsupported = errors.New("manifest schema v1 unsupported")
 
+// ErrManifestFormatUnsupported is returned when a manifest handler doesn't support a
+// specific manifest format
+var ErrManifestFormatUnsupported = errors.New("manifest format not supported by this handler")
+
 // ErrTagUnknown is returned if the given tag is not known by the tag service
 type ErrTagUnknown struct {
 	Tag string

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f // indirect
+	github.com/oci-playground/artifact-spec v0.0.0-20220506233500-8fed0a29d06f // indirect
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/prometheus/common v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/swift v1.0.47 h1:4DQRPj35Y41WogBxyhOXlrI37nzGlyEcsforeudyYPQ=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/oci-playground/artifact-spec v0.0.0-20220506233500-8fed0a29d06f h1:Dak7aFfhhP+sXD7+1OcRU31haFdKmKasKBSuJJGJEUo=
+github.com/oci-playground/artifact-spec v0.0.0-20220506233500-8fed0a29d06f/go.mod h1:NY7llZsIsyNV25K6rnp/j1/Fid+pVPxhhtO/HKCBPhk=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -1595,6 +1595,115 @@ var routeDescriptors = []RouteDescriptor{
 			},
 		},
 	},
+	{
+		Name:        RouteNameExtensionsRegistry,
+		Path:        "/v2/_ext/discover",
+		Entity:      "Extensions",
+		Description: "Retrieve information about extensions.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      "GET",
+				Description: "Retrieve a sorted, json list of extensions available at the registry level.",
+				Requests: []RequestDescriptor{
+					{
+						Name:        "Extensions",
+						Description: "Return all extensions for the registry",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
+						PathParameters: []ParameterDescriptor{
+							nameParameterDescriptor,
+						},
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode:  http.StatusOK,
+								Description: "A list of extensions for the registry.",
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json",
+									Format: `{
+    "extensions": [
+        {"name": "_<ns>/<ext>/<component>"},
+        ...
+    ]
+}`,
+								},
+							},
+						},
+						Failures: []ResponseDescriptor{
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
+							tooManyRequestsDescriptor,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		Name:        RouteNameExtensionsRepository,
+		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/_ext/discover",
+		Entity:      "Extensions",
+		Description: "Retrieve information about extensions.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      "GET",
+				Description: "Fetch the extensions under the repository identified by `name`.",
+				Requests: []RequestDescriptor{
+					{
+						Name:        "Extensions",
+						Description: "Return all extensions for the repository",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
+						PathParameters: []ParameterDescriptor{
+							nameParameterDescriptor,
+						},
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode:  http.StatusOK,
+								Description: "A list of extensions for the named repository.",
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json",
+									Format: `{
+    "name": <name>,
+    "extensions": [
+        {"name": "_<ns>/<ext>/<component>"},
+        ...
+    ]
+}`,
+								},
+							},
+						},
+						Failures: []ResponseDescriptor{
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
+							tooManyRequestsDescriptor,
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 var routeDescriptorsMap map[string]RouteDescriptor

--- a/registry/api/v2/extensions.go
+++ b/registry/api/v2/extensions.go
@@ -1,0 +1,39 @@
+package v2
+
+import (
+	"fmt"
+
+	"github.com/distribution/distribution/v3/reference"
+)
+
+// ExtendRoute extends the routes using the template.
+// The Name and Path in the template will be re-generated according to
+// - Namespace (ns)
+// - Extension Name (ext)
+// - Component name (component)
+// Returns the full route descriptor with Name and Path populated.
+// Returns true if the route is successfully extended, or false if route exists.
+func ExtendRoute(ns, ext, component string, template RouteDescriptor, nameRequired bool) (RouteDescriptor, bool) {
+	name := RouteNameExtensionsRegistry
+	path := routeDescriptorsMap[RouteNameBase].Path
+	if nameRequired {
+		name = RouteNameExtensionsRepository
+		path += "{name:" + reference.NameRegexp.String() + "}"
+	}
+	name = fmt.Sprintf("%s-%s-%s-%s", name, ns, ext, component)
+	path = fmt.Sprintf("%s/_%s/%s/%s", path, ns, ext, component)
+
+	desc := template
+	desc.Name = name
+	desc.Path = path
+
+	if _, exists := routeDescriptorsMap[desc.Name]; exists {
+		return desc, false
+	}
+
+	routeDescriptors = append(routeDescriptors, desc)
+	routeDescriptorsMap[desc.Name] = desc
+	APIDescriptor.RouteDescriptors = routeDescriptors
+
+	return desc, true
+}

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -5,13 +5,15 @@ import "github.com/gorilla/mux"
 // The following are definitions of the name under which all V2 routes are
 // registered. These symbols can be used to look up a route based on the name.
 const (
-	RouteNameBase            = "base"
-	RouteNameManifest        = "manifest"
-	RouteNameTags            = "tags"
-	RouteNameBlob            = "blob"
-	RouteNameBlobUpload      = "blob-upload"
-	RouteNameBlobUploadChunk = "blob-upload-chunk"
-	RouteNameCatalog         = "catalog"
+	RouteNameBase                 = "base"
+	RouteNameManifest             = "manifest"
+	RouteNameTags                 = "tags"
+	RouteNameBlob                 = "blob"
+	RouteNameBlobUpload           = "blob-upload"
+	RouteNameBlobUploadChunk      = "blob-upload-chunk"
+	RouteNameCatalog              = "catalog"
+	RouteNameExtensionsRegistry   = "extensions-registry"
+	RouteNameExtensionsRepository = "extensions-repository"
 )
 
 // Router builds a gorilla router with named routes for the various API

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -202,6 +202,30 @@ func (ub *URLBuilder) BuildBlobUploadChunkURL(name reference.Named, uuid string,
 	return appendValuesURL(uploadURL, values...).String(), nil
 }
 
+// BuildRegistryExtensionsURL constructs a url to list the extensions in the named repository.
+func (ub *URLBuilder) BuildRegistryExtensionsURL(values ...url.Values) (string, error) {
+	route := ub.cloneRoute(RouteNameExtensionsRegistry)
+
+	extensionsURL, err := route.URL()
+	if err != nil {
+		return "", err
+	}
+
+	return appendValuesURL(extensionsURL, values...).String(), nil
+}
+
+// BuildRepositoryExtensionsURL constructs a url to list the extensions in the named repository.
+func (ub *URLBuilder) BuildRepositoryExtensionsURL(name reference.Named, values ...url.Values) (string, error) {
+	route := ub.cloneRoute(RouteNameExtensionsRepository)
+
+	extensionsURL, err := route.URL("name", name.Name())
+	if err != nil {
+		return "", err
+	}
+
+	return appendValuesURL(extensionsURL, values...).String(), nil
+}
+
 // clondedRoute returns a clone of the named route from the router. Routes
 // must be cloned to avoid modifying them during url generation.
 func (ub *URLBuilder) cloneRoute(name string) clonedRoute {

--- a/registry/extension/distribution/manifests.go
+++ b/registry/extension/distribution/manifests.go
@@ -1,0 +1,69 @@
+package distribution
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/opencontainers/go-digest"
+)
+
+type manifestsGetAPIResponse struct {
+	Name    string          `json:"name"`
+	Digests []digest.Digest `json:"digests"`
+}
+
+// manifestHandler handles requests for manifests under a manifest name.
+type manifestHandler struct {
+	*extension.Context
+	storageDriver driver.StorageDriver
+}
+
+func (th *manifestHandler) getManifests(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	digests, err := th.manifests()
+	if err != nil {
+		switch err := err.(type) {
+		case driver.PathNotFoundError:
+			th.Errors = append(th.Errors, v2.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Named().Name()}))
+		default:
+			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(manifestsGetAPIResponse{
+		Name:    th.Repository.Named().Name(),
+		Digests: digests,
+	}); err != nil {
+		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}
+
+func (th *manifestHandler) manifests() ([]digest.Digest, error) {
+	manifestLinkStore := storage.GetManifestLinkReadOnlyBlobStore(
+		th.Context,
+		th.Repository,
+		th.storageDriver,
+		nil,
+	)
+
+	var dgsts []digest.Digest
+	err := manifestLinkStore.Enumerate(th.Context, func(dgst digest.Digest) error {
+		dgsts = append(dgsts, dgst)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dgsts, nil
+}

--- a/registry/extension/distribution/registry.go
+++ b/registry/extension/distribution/registry.go
@@ -1,0 +1,174 @@
+package distribution
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/configuration"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/gorilla/handlers"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	namespaceName           = "distribution"
+	extensionName           = "registry"
+	manifestsComponentName  = "manifests"
+	tagHistoryComponentName = "taghistory"
+	namespaceUrl            = "insert link"
+	namespaceDescription    = "distribution extension adds tag history and manifest list functionality"
+)
+
+type distributionNamespace struct {
+	storageDriver     driver.StorageDriver
+	manifestsEnabled  bool
+	tagHistoryEnabled bool
+}
+
+type distributionOptions struct {
+	RegExtensionComponents []string `yaml:"registry,omitempty"`
+}
+
+// newDistNamespace creates a new extension namespace with the name "distribution"
+func newDistNamespace(ctx context.Context, storageDriver driver.StorageDriver, options configuration.ExtensionConfig) (extension.Namespace, error) {
+
+	optionsYaml, err := yaml.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+
+	var distOptions distributionOptions
+	err = yaml.Unmarshal(optionsYaml, &distOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	manifestsEnabled := false
+	tagHistoryEnabled := false
+	for _, component := range distOptions.RegExtensionComponents {
+		switch component {
+		case "manifests":
+			manifestsEnabled = true
+		case "taghistory":
+			tagHistoryEnabled = true
+		}
+	}
+
+	return &distributionNamespace{
+		storageDriver:     storageDriver,
+		manifestsEnabled:  manifestsEnabled,
+		tagHistoryEnabled: tagHistoryEnabled,
+	}, nil
+}
+
+func init() {
+	// register the extension namespace.
+	extension.Register(namespaceName, newDistNamespace)
+}
+
+// GetManifestHandlers returns a list of manifest handlers that will be registered in the manifest store.
+func (o *distributionNamespace) GetManifestHandlers(repo distribution.Repository, blobStore distribution.BlobStore) []storage.ManifestHandler {
+	// This extension doesn't extend any manifest store operations.
+	return []storage.ManifestHandler{}
+}
+
+// GetRepositoryRoutes returns a list of extension routes scoped at a repository level
+func (d *distributionNamespace) GetRepositoryRoutes() []extension.Route {
+	var routes []extension.Route
+
+	if d.manifestsEnabled {
+		routes = append(routes, extension.Route{
+			Namespace: namespaceName,
+			Extension: extensionName,
+			Component: manifestsComponentName,
+			Descriptor: v2.RouteDescriptor{
+				Entity: "Manifest",
+				Methods: []v2.MethodDescriptor{
+					{
+						Method:      "GET",
+						Description: "Get all manifest digests for a given repository. Currently the API doesn't support pagination.",
+					},
+				},
+			},
+			Dispatcher: d.manifestsDispatcher,
+		})
+	}
+
+	if d.tagHistoryEnabled {
+		routes = append(routes, extension.Route{
+			Namespace: namespaceName,
+			Extension: extensionName,
+			Component: tagHistoryComponentName,
+			Descriptor: v2.RouteDescriptor{
+				Entity: "TagHistory",
+				Methods: []v2.MethodDescriptor{
+					{
+						Method:      "GET",
+						Description: "Get a set of digests that the specified tag historically pointed to",
+						Requests: []v2.RequestDescriptor{
+							{
+								QueryParameters: []v2.ParameterDescriptor{
+									{
+										Name:     "tag",
+										Type:     "string",
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Dispatcher: d.tagHistoryDispatcher,
+		})
+	}
+
+	return routes
+}
+
+// GetRegistryRoutes returns a list of extension routes scoped at a registry level
+// There are no registry scoped routes exposed by this namespace
+func (d *distributionNamespace) GetRegistryRoutes() []extension.Route {
+	return nil
+}
+
+// GetNamespaceName returns the name associated with the namespace
+func (d *distributionNamespace) GetNamespaceName() string {
+	return namespaceName
+}
+
+// GetNamespaceUrl returns the url link to the documentation where the namespace's extension and endpoints are defined
+func (d *distributionNamespace) GetNamespaceUrl() string {
+	return namespaceUrl
+}
+
+// GetNamespaceDescription returns the description associated with the namespace
+func (d *distributionNamespace) GetNamespaceDescription() string {
+	return namespaceDescription
+}
+
+func (d *distributionNamespace) tagHistoryDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
+	tagHistoryHandler := &tagHistoryHandler{
+		Context:       ctx,
+		storageDriver: d.storageDriver,
+	}
+
+	return handlers.MethodHandler{
+		"GET": http.HandlerFunc(tagHistoryHandler.getTagManifestDigests),
+	}
+}
+
+func (d *distributionNamespace) manifestsDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
+	manifestsHandler := &manifestHandler{
+		Context:       ctx,
+		storageDriver: d.storageDriver,
+	}
+
+	return handlers.MethodHandler{
+		"GET": http.HandlerFunc(manifestsHandler.getManifests),
+	}
+}

--- a/registry/extension/distribution/taghistory.go
+++ b/registry/extension/distribution/taghistory.go
@@ -1,0 +1,78 @@
+package distribution
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/opencontainers/go-digest"
+)
+
+type tagHistoryAPIResponse struct {
+	Name    string          `json:"name"`
+	Tag     string          `json:"tag"`
+	Digests []digest.Digest `json:"digests"`
+}
+
+// manifestHandler handles requests for manifests under a manifest name.
+type tagHistoryHandler struct {
+	*extension.Context
+	storageDriver driver.StorageDriver
+}
+
+func (th *tagHistoryHandler) getTagManifestDigests(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	q := r.URL.Query()
+	tag := q.Get("tag")
+	if tag == "" {
+		th.Errors = append(th.Errors, v2.ErrorCodeTagInvalid.WithDetail(tag))
+		return
+	}
+
+	digests, err := th.manifestDigests(tag)
+	if err != nil {
+		switch err := err.(type) {
+		case driver.PathNotFoundError:
+			th.Errors = append(th.Errors, v2.ErrorCodeManifestUnknown.WithDetail(map[string]string{"tag": tag}))
+		default:
+			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(tagHistoryAPIResponse{
+		Name:    th.Repository.Named().Name(),
+		Tag:     tag,
+		Digests: digests,
+	}); err != nil {
+		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}
+
+func (th *tagHistoryHandler) manifestDigests(tag string) ([]digest.Digest, error) {
+	tagLinkStore := storage.GetTagLinkReadOnlyBlobStore(
+		th.Context,
+		th.Repository,
+		th.storageDriver,
+		tag,
+	)
+
+	var dgsts []digest.Digest
+	err := tagLinkStore.Enumerate(th.Context, func(dgst digest.Digest) error {
+		dgsts = append(dgsts, dgst)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dgsts, nil
+}

--- a/registry/extension/extension.go
+++ b/registry/extension/extension.go
@@ -1,0 +1,133 @@
+package extension
+
+import (
+	"context"
+	c "context"
+	"fmt"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/configuration"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+)
+
+// Context contains the request specific context for use in across handlers.
+type Context struct {
+	c.Context
+
+	// Registry is the base namespace that is used by all extension namespaces
+	Registry distribution.Namespace
+	// Repository is a reference to a named repository
+	Repository distribution.Repository
+	// Errors are the set of errors that occurred within this request context
+	Errors errcode.Errors
+}
+
+// RouteDispatchFunc is the http route dispatcher used by the extension route handlers
+type RouteDispatchFunc func(extContext *Context, r *http.Request) http.Handler
+
+// Route describes an extension route.
+type Route struct {
+	// Namespace is the name of the extension namespace
+	Namespace string
+	// Extension is the name of the extension under the namespace
+	Extension string
+	// Component is the name of the component under the extension
+	Component string
+	// Descriptor is the route descriptor that gives its path
+	Descriptor v2.RouteDescriptor
+	// Dispatcher if present signifies that the route is http route with a dispatcher
+	Dispatcher RouteDispatchFunc
+}
+
+// Namespace is the namespace that is used to define extensions to the distribution.
+type Namespace interface {
+	storage.ExtendedStorage
+	// GetRepositoryRoutes returns a list of extension routes scoped at a repository level
+	GetRepositoryRoutes() []Route
+	// GetRegistryRoutes returns a list of extension routes scoped at a registry level
+	GetRegistryRoutes() []Route
+	// GetNamespaceName returns the name associated with the namespace
+	GetNamespaceName() string
+	// GetNamespaceUrl returns the url link to the documentation where the namespace's extension and endpoints are defined
+	GetNamespaceUrl() string
+	// GetNamespaceDescription returns the description associated with the namespace
+	GetNamespaceDescription() string
+}
+
+// InitExtensionNamespace is the initialize function for creating the extension namespace
+type InitExtensionNamespace func(ctx c.Context, storageDriver driver.StorageDriver, options configuration.ExtensionConfig) (Namespace, error)
+
+// EnumerateExtension specifies extension information at the namespace level
+type EnumerateExtension struct {
+	Name        string   `json:"name"`
+	Url         string   `json:"url"`
+	Description string   `json:"description,omitempty"`
+	Endpoints   []string `json:"endpoints"`
+}
+
+var extensions map[string]InitExtensionNamespace
+var extensionsNamespaces map[string]Namespace
+
+func EnumerateRegistered(ctx context.Context) (enumeratedExtensions []EnumerateExtension) {
+	for _, namespace := range extensionsNamespaces {
+		enumerateExtension := EnumerateExtension{
+			Name:        namespace.GetNamespaceName(),
+			Url:         namespace.GetNamespaceUrl(),
+			Description: namespace.GetNamespaceDescription(),
+		}
+
+		registryScoped := namespace.GetRegistryRoutes()
+		for _, regScoped := range registryScoped {
+			path := fmt.Sprintf("_%s/%s/%s", regScoped.Namespace, regScoped.Extension, regScoped.Component)
+			enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+		}
+
+		repositoryScoped := namespace.GetRepositoryRoutes()
+		for _, repScoped := range repositoryScoped {
+			path := fmt.Sprintf("_%s/%s/%s", repScoped.Namespace, repScoped.Extension, repScoped.Component)
+			enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+		}
+
+		enumeratedExtensions = append(enumeratedExtensions, enumerateExtension)
+	}
+
+	return enumeratedExtensions
+}
+
+// Register is used to register an InitExtensionNamespace for
+// an extension namespace with the given name.
+func Register(name string, initFunc InitExtensionNamespace) {
+	if extensions == nil {
+		extensions = make(map[string]InitExtensionNamespace)
+	}
+
+	if _, exists := extensions[name]; exists {
+		panic(fmt.Sprintf("namespace name already registered: %s", name))
+	}
+
+	extensions[name] = initFunc
+}
+
+// Get constructs an extension namespace with the given options using the given name.
+func Get(ctx c.Context, name string, storageDriver driver.StorageDriver, options configuration.ExtensionConfig) (Namespace, error) {
+	if extensions != nil {
+		if extensionsNamespaces == nil {
+			extensionsNamespaces = make(map[string]Namespace)
+		}
+
+		if initFunc, exists := extensions[name]; exists {
+			namespace, err := initFunc(ctx, storageDriver, options)
+			if err == nil {
+				// adds the initialized namespace to map for simple access to namespaces by EnumerateRegistered
+				extensionsNamespaces[name] = namespace
+			}
+			return namespace, err
+		}
+	}
+
+	return nil, fmt.Errorf("no extension registered with name: %s", name)
+}

--- a/registry/extension/oci/artifactmanifest.go
+++ b/registry/extension/oci/artifactmanifest.go
@@ -1,0 +1,106 @@
+package oci
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/distribution/distribution/v3"
+	v2 "github.com/oci-playground/artifact-spec/specs-go/v1"
+	"github.com/opencontainers/go-digest"
+)
+
+func init() {
+	unmarshalFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		d := new(DeserializedManifest)
+		err := d.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return d, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v2.MediaTypeArtifactManifest}, err
+	}
+	err := distribution.RegisterManifestSchema(v2.MediaTypeArtifactManifest, unmarshalFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register ORAS artifact manifest: %s", err))
+	}
+}
+
+// Manifest describes ORAS artifact manifests.
+type Manifest struct {
+	inner v2.ArtifactManifest
+}
+
+// ArtifactType returns the artifactType of this ORAS artifact.
+// sajayantony - discuss if we need artifact type or depend or
+// annotation filtering
+// func (a Manifest) ArtifactType() string {
+// 	return a.inner.ArtifactType
+// }
+
+// References returns the distribution descriptors for the referenced blobs.
+func (a Manifest) References() []distribution.Descriptor {
+	blobs := make([]distribution.Descriptor, len(a.inner.Blobs))
+	for i := range a.inner.Blobs {
+		blobs[i] = distribution.Descriptor{
+			MediaType: a.inner.Blobs[i].MediaType,
+			Digest:    a.inner.Blobs[i].Digest,
+			Size:      a.inner.Blobs[i].Size,
+		}
+	}
+	return blobs
+}
+
+// Subject returns the the subject manifest this artifact references.
+func (a Manifest) Subject() distribution.Descriptor {
+	return distribution.Descriptor{
+		MediaType: a.inner.Reference.MediaType,
+		Digest:    a.inner.Reference.Digest,
+		Size:      a.inner.Reference.Size,
+	}
+}
+
+// DeserializedManifest wraps Manifest with a copy of the original JSON data.
+type DeserializedManifest struct {
+	Manifest
+
+	// raw is the raw byte representation of the ORAS artifact.
+	raw []byte
+}
+
+// UnmarshalJSON populates a new Manifest struct from JSON data.
+func (d *DeserializedManifest) UnmarshalJSON(b []byte) error {
+	d.raw = make([]byte, len(b))
+	copy(d.raw, b)
+
+	var man v2.ArtifactManifest
+	if err := json.Unmarshal(d.raw, &man); err != nil {
+		return err
+	}
+
+	// sajayantony ArtifactType
+	// if man.ArtifactType == "" {
+	// 	//return errors.New("artifactType cannot be empty")
+	// 	logrus.Warn("Artifact Type cannog be empty")
+	// }
+	d.inner = man
+
+	return nil
+}
+
+// MarshalJSON returns the raw content.
+func (d *DeserializedManifest) MarshalJSON() ([]byte, error) {
+	if len(d.raw) > 0 {
+		return d.raw, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedManifest")
+}
+
+// Payload returns the raw content of the Artifact. The contents can be
+// used to calculate the content identifier.
+func (d DeserializedManifest) Payload() (string, []byte, error) {
+	// NOTE: This is a hack. The media type should be read from storage.
+	return v2.MediaTypeArtifactManifest, d.raw, nil
+}

--- a/registry/extension/oci/artifactmanifesthandler.go
+++ b/registry/extension/oci/artifactmanifesthandler.go
@@ -1,0 +1,137 @@
+package oci
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/opencontainers/go-digest"
+)
+
+// artifactManifestHandler is a ManifestHandler that covers ORAS Artifacts.
+type artifactManifestHandler struct {
+	repository    distribution.Repository
+	blobStore     distribution.BlobStore
+	storageDriver driver.StorageDriver
+}
+
+func (amh *artifactManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	dcontext.GetLogger(ctx).Debug("(*artifactManifestHandler).Unmarshal")
+
+	var v json.RawMessage
+	if json.Unmarshal(content, &v) != nil {
+		return nil, distribution.ErrManifestFormatUnsupported
+	}
+
+	dm := &DeserializedManifest{}
+	if err := dm.UnmarshalJSON(content); err != nil {
+		return nil, distribution.ErrManifestFormatUnsupported
+	}
+
+	return dm, nil
+}
+
+func (ah *artifactManifestHandler) Put(ctx context.Context, man distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
+	dcontext.GetLogger(ctx).Debug("(*artifactManifestHandler).Put")
+
+	da, ok := man.(*DeserializedManifest)
+	if !ok {
+		return "", distribution.ErrManifestFormatUnsupported
+	}
+
+	if err := ah.verifyManifest(ctx, *da, skipDependencyVerification); err != nil {
+		return "", err
+	}
+
+	mt, payload, err := da.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	revision, err := ah.blobStore.Put(ctx, mt, payload)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error putting payload into blobstore: %v", err)
+		return "", err
+	}
+
+	err = ah.indexReferrers(ctx, *da, revision.Digest)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error indexing referrers: %v", err)
+		return "", err
+	}
+
+	return revision.Digest, nil
+}
+
+// verifyManifest ensures that the manifest content is valid from the
+// perspective of the registry. As a policy, the registry only tries to
+// store valid content, leaving trust policies of that content up to
+// consumers.
+func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm DeserializedManifest, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	// if dm.ArtifactType() == "" {
+	// 	// sajayantony: Consider making artifact type required
+	// 	//errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
+	// 	logrus.Warn("Artifact type is empty.")
+	// }
+
+	if !skipDependencyVerification {
+		bs := amh.repository.Blobs(ctx)
+
+		// All references must exist.
+		for _, blobDesc := range dm.References() {
+			desc, err := bs.Stat(ctx, blobDesc.Digest)
+			if err != nil && err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+			}
+			if err != nil || desc.Digest == "" {
+				// On error here, we always append unknown blob errors.
+				errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: blobDesc.Digest})
+			}
+		}
+
+		ms, err := amh.repository.Manifests(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Validate subject manifest.
+		subject := dm.Subject()
+		exists, err := ms.Exists(ctx, subject.Digest)
+		if !exists || err == distribution.ErrBlobUnknown {
+			errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: subject.Digest})
+		} else if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
+// indexReferrers indexes the subject of the given revision in its referrers index store.
+func (amh *artifactManifestHandler) indexReferrers(ctx context.Context, dm DeserializedManifest, revision digest.Digest) error {
+	// [TODO] We can use artifact type in the link path to support filtering by artifact type
+	//  but need to consider the max path length in different os
+	//artifactType := dm.ArtifactType()
+	subjectRevision := dm.Subject().Digest
+
+	rootPath := path.Join(referrersLinkPath(amh.repository.Named().Name()), subjectRevision.Algorithm().String(), subjectRevision.Hex())
+	referenceLinkPath := path.Join(rootPath, revision.Algorithm().String(), revision.Hex(), "link")
+	if err := amh.storageDriver.PutContent(ctx, referenceLinkPath, []byte(revision.String())); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func referrersLinkPath(name string) string {
+	return path.Join("/docker/registry/", "v2", "repositories", name, "_refs", "subjects")
+}

--- a/registry/extension/oci/artifactservice.go
+++ b/registry/extension/oci/artifactservice.go
@@ -1,0 +1,133 @@
+package oci
+
+import (
+	"context"
+	"path"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ArtifactService interface {
+	Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]v1.Descriptor, error)
+}
+
+// referrersHandler handles http operations on manifest referrers.
+type referrersHandler struct {
+	extContext    *extension.Context
+	storageDriver driver.StorageDriver
+
+	// Digest is the target manifest's digest.
+	Digest digest.Digest
+}
+
+func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]v1.Descriptor, error) {
+	dcontext.GetLogger(ctx).Debug("(*manifestStore).Referrers")
+
+	var referrers []v1.Descriptor
+
+	repo := h.extContext.Repository
+	manifests, err := repo.Manifests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	blobStatter := h.extContext.Registry.BlobStatter()
+	rootPath := path.Join(referrersLinkPath(repo.Named().Name()), revision.Algorithm().String(), revision.Hex())
+	err = h.enumerateReferrerLinks(ctx, rootPath, func(referrerRevision digest.Digest) error {
+		man, err := manifests.Get(ctx, referrerRevision)
+		if err != nil {
+			return err
+		}
+
+		_, ok := man.(*DeserializedManifest)
+		//fmt.Printf("Artifact type requested %s", artifact.ArtifactType())
+
+		if !ok {
+			// The PUT handler would guard against this situation. Skip this manifest.
+			return nil
+		}
+
+		desc, err := blobStatter.Stat(ctx, referrerRevision)
+		if err != nil {
+			return err
+		}
+		desc.MediaType, _, _ = man.Payload()
+		referrers = append(referrers, v1.Descriptor{
+			MediaType: desc.MediaType,
+			Size:      desc.Size,
+			Digest:    desc.Digest,
+			//Todo: annontate artifactType
+			//ArtifactType: ArtifactMan.ArtifactType(),
+		})
+		return nil
+	})
+
+	if err != nil {
+		switch err.(type) {
+		case driver.PathNotFoundError:
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return referrers, nil
+}
+func (h *referrersHandler) enumerateReferrerLinks(ctx context.Context, rootPath string, ingestor func(digest.Digest) error) error {
+	blobStatter := h.extContext.Registry.BlobStatter()
+
+	return h.storageDriver.Walk(ctx, rootPath, func(fileInfo driver.FileInfo) error {
+		// exit early if directory...
+		if fileInfo.IsDir() {
+			return nil
+		}
+		filePath := fileInfo.Path()
+
+		// check if it's a link
+		_, fileName := path.Split(filePath)
+		if fileName != "link" {
+			return nil
+		}
+
+		// read the digest found in link
+		digest, err := h.readlink(ctx, filePath)
+		if err != nil {
+			return err
+		}
+
+		// ensure this conforms to the linkPathFns
+		_, err = blobStatter.Stat(ctx, digest)
+		if err != nil {
+			// we expect this error to occur so we move on
+			if err == distribution.ErrBlobUnknown {
+				return nil
+			}
+			return err
+		}
+
+		err = ingestor(digest)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (h *referrersHandler) readlink(ctx context.Context, path string) (digest.Digest, error) {
+	content, err := h.storageDriver.GetContent(ctx, path)
+	if err != nil {
+		return "", err
+	}
+
+	linked, err := digest.Parse(string(content))
+	if err != nil {
+		return "", err
+	}
+
+	return linked, nil
+}

--- a/registry/extension/oci/discover.go
+++ b/registry/extension/oci/discover.go
@@ -1,0 +1,46 @@
+package oci
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+)
+
+type discoverGetAPIResponse struct {
+	Name       string                         `json:"name"`
+	Extensions []extension.EnumerateExtension `json:"extensions"`
+}
+
+// extensionHandler handles requests for manifests under a manifest name.
+type extensionHandler struct {
+	*extension.Context
+	storageDriver driver.StorageDriver
+}
+
+func (th *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	// get list of extension information seperated at the namespace level
+	enumeratedExtensions := extension.EnumerateRegistered(r.Context())
+
+	// // remove the oci extension so it's not returned by discover
+	// for i, e := range enumeratedExtensions {
+	// 	if e.Name == namespaceName {
+	// 		enumeratedExtensions = append(enumeratedExtensions[:i], enumeratedExtensions[i+1:]...)
+	// 	}
+	// }
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(discoverGetAPIResponse{
+		Name:       th.Repository.Named().Name(),
+		Extensions: enumeratedExtensions,
+	}); err != nil {
+		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}

--- a/registry/extension/oci/oci.go
+++ b/registry/extension/oci/oci.go
@@ -1,0 +1,194 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/configuration"
+	dcontext "github.com/distribution/distribution/v3/context"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/extension"
+	"github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	namespaceName         = "oci"
+	extensionName         = "ext"
+	discoverComponentName = "discover"
+	namespaceUrl          = "https://github.com/opencontainers/distribution-spec/blob/main/extensions/_oci.md"
+	namespaceDescription  = "oci extension enables listing of supported registry and repository extensions"
+
+	artifactsExtensiontName = "artifacts"
+	referrersComponentName  = "referrers"
+)
+
+type ociNamespace struct {
+	storageDriver    driver.StorageDriver
+	discoverEnabled  bool
+	referrersEnabled bool
+}
+
+type ociOptions struct {
+	RegExtensionComponents      []string `yaml:"ext,omitempty"`
+	ArtifactExtensionComponents []string `yaml:"artifacts,omitempty"`
+}
+
+// newOciNamespace creates a new extension namespace with the name "oci"
+func newOciNamespace(ctx context.Context, storageDriver driver.StorageDriver, options configuration.ExtensionConfig) (extension.Namespace, error) {
+	optionsYaml, err := yaml.Marshal(options)
+	if err != nil {
+		return nil, err
+	}
+
+	var ociOption ociOptions
+	err = yaml.Unmarshal(optionsYaml, &ociOption)
+	if err != nil {
+		return nil, err
+	}
+
+	discoverEnabled := false
+	for _, component := range ociOption.RegExtensionComponents {
+		switch component {
+		case "discover":
+			discoverEnabled = true
+		}
+		fmt.Println(component)
+	}
+
+	referrersEnabled := false
+	for _, component := range ociOption.ArtifactExtensionComponents {
+		switch component {
+		case "referrers":
+			referrersEnabled = true
+		}
+		fmt.Println(component)
+	}
+
+	return &ociNamespace{
+		storageDriver:    storageDriver,
+		discoverEnabled:  discoverEnabled,
+		referrersEnabled: referrersEnabled,
+	}, nil
+}
+
+func init() {
+	// register the extension namespace.
+	extension.Register(namespaceName, newOciNamespace)
+}
+
+// GetManifestHandlers returns a list of manifest handlers that will be registered in the manifest store.
+func (o *ociNamespace) GetManifestHandlers(repo distribution.Repository, blobStore distribution.BlobStore) []storage.ManifestHandler {
+	if o.referrersEnabled {
+		return []storage.ManifestHandler{
+			&artifactManifestHandler{
+				repository:    repo,
+				blobStore:     blobStore,
+				storageDriver: o.storageDriver,
+			}}
+	}
+
+	return []storage.ManifestHandler{}
+}
+
+// GetRepositoryRoutes returns a list of extension routes scoped at a repository level
+func (d *ociNamespace) GetRepositoryRoutes() []extension.Route {
+	var routes []extension.Route
+
+	if d.discoverEnabled {
+		routes = append(routes, extension.Route{
+			Namespace: namespaceName,
+			Extension: extensionName,
+			Component: discoverComponentName,
+			Descriptor: v2.RouteDescriptor{
+				Entity: "Extension",
+				Methods: []v2.MethodDescriptor{
+					{
+						Method:      "GET",
+						Description: "Get all extensions enabled for a repository.",
+					},
+				},
+			},
+			Dispatcher: d.discoverDispatcher,
+		})
+	}
+
+	if d.referrersEnabled {
+		routes = append(routes, extension.Route{
+			Namespace: namespaceName,
+			Extension: artifactsExtensiontName,
+			Component: referrersComponentName,
+			Descriptor: v2.RouteDescriptor{
+				Entity: "Referrers",
+				Methods: []v2.MethodDescriptor{
+					{
+						Method:      "GET",
+						Description: "Get all referrers for the given digest. Currently the API doesn't support pagination.",
+					},
+				},
+			},
+			Dispatcher: d.referrersDispatcher,
+		})
+	}
+
+	return routes
+}
+
+// GetRegistryRoutes returns a list of extension routes scoped at a registry level
+// There are no registry scoped routes exposed by this namespace
+func (d *ociNamespace) GetRegistryRoutes() []extension.Route {
+	return nil
+}
+
+// GetNamespaceName returns the name associated with the namespace
+func (d *ociNamespace) GetNamespaceName() string {
+	return namespaceName
+}
+
+// GetNamespaceUrl returns the url link to the documentation where the namespace's extension and endpoints are defined
+func (d *ociNamespace) GetNamespaceUrl() string {
+	return namespaceUrl
+}
+
+// GetNamespaceDescription returns the description associated with the namespace
+func (d *ociNamespace) GetNamespaceDescription() string {
+	return namespaceDescription
+}
+
+func (d *ociNamespace) discoverDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
+	extensionHandler := &extensionHandler{
+		Context:       ctx,
+		storageDriver: d.storageDriver,
+	}
+
+	return handlers.MethodHandler{
+		"GET": http.HandlerFunc(extensionHandler.getExtensions),
+	}
+}
+
+func (o *ociNamespace) referrersDispatcher(extCtx *extension.Context, r *http.Request) http.Handler {
+
+	handler := &referrersHandler{
+		storageDriver: o.storageDriver,
+		extContext:    extCtx,
+	}
+	q := r.URL.Query()
+	if dgstStr := q.Get("digest"); dgstStr == "" {
+		dcontext.GetLogger(extCtx).Errorf("digest not available")
+	} else if d, err := digest.Parse(dgstStr); err != nil {
+		dcontext.GetLogger(extCtx).Errorf("error parsing digest=%q: %v", dgstStr, err)
+	} else {
+		handler.Digest = d
+	}
+
+	mhandler := handlers.MethodHandler{
+		"GET": http.HandlerFunc(handler.getReferrers),
+	}
+
+	return mhandler
+}

--- a/registry/extension/oci/referrers.go
+++ b/registry/extension/oci/referrers.go
@@ -1,0 +1,65 @@
+package oci
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3"
+	dcontext "github.com/distribution/distribution/v3/context"
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/opencontainers/image-spec/specs-go"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// referrersResponse describes the response body of the referrers API.
+//sajayantony - use the index type here.
+// type referrersResponse struct {
+// 	Referrers []v1.Descriptor `json:"manifests"`
+// }
+
+func (h *referrersHandler) getReferrers(w http.ResponseWriter, r *http.Request) {
+	dcontext.GetLogger(h.extContext).Debug("Get")
+
+	// This can be empty
+	artifactType := r.FormValue("artifactType")
+
+	if h.Digest == "" {
+		h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeManifestUnknown.WithDetail("digest not specified"))
+		return
+	}
+
+	referrers, err := h.Referrers(h.extContext, h.Digest, artifactType)
+	if err != nil {
+		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
+			h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+		} else {
+			h.extContext.Errors = append(h.extContext.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	if referrers == nil {
+		referrers = []v1.Descriptor{}
+	}
+
+	// response := referrersResponse{
+	// 	Referrers: referrers,
+	// }
+
+	response := v1.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests:   referrers,
+		Annotations: map[string]string{},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	//w.Header().Set("OCI-Api-Version", "oci/2.0")
+	enc := json.NewEncoder(w)
+	if err = enc.Encode(response); err != nil {
+		h.extContext.Errors = append(h.extContext.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}

--- a/registry/handlers/extensions.go
+++ b/registry/handlers/extensions.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+	"github.com/gorilla/handlers"
+)
+
+// extensionsDispatcher constructs the extensions handler api endpoint.
+func extensionsDispatcher(ctx *Context, r *http.Request) http.Handler {
+	extensionsHandler := &extensionsHandler{
+		Context: ctx,
+	}
+
+	return handlers.MethodHandler{
+		"GET": http.HandlerFunc(extensionsHandler.GetExtensions),
+	}
+}
+
+// extensionsHandler handles requests for lists of extensions under a repository name.
+type extensionsHandler struct {
+	*Context
+}
+type extensionResponse struct {
+	Name string `json:"name,omitempty"`
+}
+
+type extensionsAPIResponse struct {
+	Name       string              `json:"name,omitempty"`
+	Extensions []extensionResponse `json:"extensions"`
+}
+
+// GetExtensions returns a json list of extensions for a specific repo name.
+func (eh *extensionsHandler) GetExtensions(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	// TODO: pagination support.
+
+	w.Header().Set("Content-Type", "application/json")
+
+	extensionNames := eh.registryExtensions
+	if eh.Repository != nil {
+		extensionNames = eh.repositoryExtensions
+	}
+
+	var extensions []extensionResponse
+	for _, ext := range extensionNames {
+		extensions = append(extensions, extensionResponse{Name: ext})
+	}
+
+	var resp extensionsAPIResponse
+	if eh.Repository != nil {
+		resp = extensionsAPIResponse{
+			Name:       eh.Repository.Named().Name(),
+			Extensions: extensions,
+		}
+	} else {
+		resp = extensionsAPIResponse{
+			Extensions: extensions,
+		}
+	}
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(resp); err != nil {
+		eh.Errors = append(eh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}

--- a/registry/storage/extension.go
+++ b/registry/storage/extension.go
@@ -1,0 +1,117 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/distribution/distribution/v3"
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/opencontainers/go-digest"
+)
+
+// ReadOnlyBlobStore represent the suite of readonly operations for blobs.
+type ReadOnlyBlobStore interface {
+	distribution.BlobEnumerator
+	distribution.BlobStatter
+	distribution.BlobProvider
+}
+
+// ExtendedStorage defines extensions to store operations like manifest for example.
+type ExtendedStorage interface {
+	// GetManifestHandlers returns the list of manifest handlers that handle custom manifest formats supported by the extensions.
+	GetManifestHandlers(
+		repo distribution.Repository,
+		blobStore distribution.BlobStore) []ManifestHandler
+}
+
+// GetManifestLinkReadOnlyBlobStore will enable extensions to access the underlying linked blob store for readonly operations.
+// This blob store is scoped only to manifest link paths. Manifest link paths doesn't use blob cache
+func GetManifestLinkReadOnlyBlobStore(
+	ctx context.Context,
+	repo distribution.Repository,
+	driver storagedriver.StorageDriver,
+	blobDescriptorServiceFactory distribution.BlobDescriptorServiceFactory,
+) ReadOnlyBlobStore {
+
+	manifestLinkPathFns := []linkPathFunc{
+		manifestRevisionLinkPath,
+	}
+
+	manifestDirectoryPathSpec := manifestRevisionsPathSpec{name: repo.Named().Name()}
+
+	// create global statter
+	bstatter := &blobStatter{
+		driver: driver,
+	}
+
+	bs := &blobStore{
+		driver:  driver,
+		statter: bstatter,
+	}
+
+	var statter distribution.BlobDescriptorService = &linkedBlobStatter{
+		blobStore:   bs,
+		repository:  repo,
+		linkPathFns: manifestLinkPathFns,
+	}
+
+	if blobDescriptorServiceFactory != nil {
+		statter = blobDescriptorServiceFactory.BlobAccessController(statter)
+	}
+
+	return &linkedBlobStore{
+		ctx:                  ctx,
+		blobStore:            bs,
+		repository:           repo,
+		blobAccessController: statter,
+
+		// linkPath limits this blob store to only
+		// manifests. This instance cannot be used for blob checks.
+		linkPathFns:           manifestLinkPathFns,
+		linkDirectoryPathSpec: manifestDirectoryPathSpec,
+	}
+}
+
+// GetTagLinkReadOnlyBlobStore will enable extensions to access the underlying linked blob store for readonly operations.
+// This blob store is scoped only to tag link paths. Tag link paths doesn't use blob cache
+func GetTagLinkReadOnlyBlobStore(
+	ctx context.Context,
+	repo distribution.Repository,
+	driver storagedriver.StorageDriver,
+	tag string) ReadOnlyBlobStore {
+
+	var tagLinkPath = func(name string, dgst digest.Digest) (string, error) {
+		return pathFor(manifestTagIndexEntryLinkPathSpec{
+			name:     name,
+			tag:      tag,
+			revision: dgst,
+		})
+	}
+
+	// create global statter
+	statter := &blobStatter{
+		driver: driver,
+	}
+
+	bs := &blobStore{
+		driver:  driver,
+		statter: statter,
+	}
+
+	return &linkedBlobStore{
+		blobStore: bs,
+		blobAccessController: &linkedBlobStatter{
+			blobStore:   bs,
+			repository:  repo,
+			linkPathFns: []linkPathFunc{manifestRevisionLinkPath},
+		},
+		repository: repo,
+		ctx:        ctx,
+		// linkPath limits this blob store to only
+		// tags.
+		linkPathFns: []linkPathFunc{tagLinkPath},
+		linkDirectoryPathSpec: manifestTagIndexPathSpec{
+			name: repo.Named().Name(),
+			tag:  tag,
+		},
+	}
+}

--- a/vendor/github.com/oci-playground/artifact-spec/LICENSE
+++ b/vendor/github.com/oci-playground/artifact-spec/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/oci-playground/artifact-spec/specs-go/v1/artifact.go
+++ b/vendor/github.com/oci-playground/artifact-spec/specs-go/v1/artifact.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+// Artifact describes an artifact manifest.
+// This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+type ArtifactManifest struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []v1.Descriptor `json:"blobs"`
+
+	// Reference is an optional link to any existing manifest within the repository.
+	Reference v1.Descriptor `json:"reference"`
+
+	// Annotations contains arbitrary metadata for the artifact manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/oci-playground/artifact-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/oci-playground/artifact-spec/specs-go/v1/mediatype.go
@@ -1,0 +1,20 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+const (
+	// MediaTypeArtifactManifest specifies the media type for a content descriptor.
+	MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,6 +161,9 @@ github.com/mitchellh/mapstructure
 ## explicit
 github.com/ncw/swift
 github.com/ncw/swift/swifttest
+# github.com/oci-playground/artifact-spec v0.0.0-20220506233500-8fed0a29d06f
+## explicit; go 1.17
+github.com/oci-playground/artifact-spec/specs-go/v1
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest


### PR DESCRIPTION
- Make and run the registry with the sample config in the repo

```bash
./bin/registry serve cmd/registry/config-example-with-extensions.yml
```

- You can view the manifests using a test extension 

```bash
➜ http -b :5000/v2/reftype-test/_distribution/registry/manifests
{
    "digests": [
        "sha256:28ffe613ed468b4aa3b60061f529ef676144d47bfc7067bd465d58e370f07718",
        "sha256:65b3a80ebe7471beecbc090c5b2cdd0aafeaefa0715f8f12e40dc918a3a70e32"
    ],
    "name": "reftype-test"
}
```

In the above, digest `65b3a80` is an image and `28ffe6` refers to that image. You can query the first digest for things that refer to it. 

```bash
➜ http -b 'localhost:5000/v2/reftype-test/_oci/artifacts/referrers?digest=sha256:65b3a80ebe7471beecbc090c5b2cdd0aafeaefa0715f8f12e40dc918a3a70e32'
{
    "manifests": [
        {
            "digest": "sha256:28ffe613ed468b4aa3b60061f529ef676144d47bfc7067bd465d58e370f07718",
            "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
            "size": 491
        }
    ],
    "schemaVersion": 2
}
```

- Here is the manifest for the artifact using the artifact manifest defined - 

https://github.com/oci-playground/artifact-spec/blob/8fed0a29d06fc27c88c787722707af59499c30b5/specs-go/v1/artifact.go#L21-L33

![image](https://user-images.githubusercontent.com/1821104/167232835-88087d50-42b2-46b4-b8ce-c5f33e23f5e2.png)
