### PR TITLE
Fix descriptor type on OCIv1 manifest

### DIFF
--- a/registry/storage/ocimanifesthandler.go
+++ b/registry/storage/ocimanifesthandler.go
@@ -60,7 +60,7 @@ func (ms *ocischemaManifestHandler) Put(ctx context.Context, manifest distributi
 		return "", err
 	}
 
-	if !reflect.DeepEqual(m.Reference, v1.Descriptor{}) {
+	if !reflect.DeepEqual(m.Reference, distribution.Descriptor{}) {
 		// add link file here if Reference field isn't empty
 		err = ms.indexReferrers(ctx, m, revision.Digest)
 		if err != nil {


### PR DESCRIPTION
The descriptor type was incorrect which resulted in the referrers check running for all OCI manifests even if they didn't have a refers field. That triggered #11 .

Fixes #11 

Signed-off-by: Brandon Mitchell <git@bmitch.net>