### PR TITLE
fix: make artifact manifest handler accept nil subject

### DIFF
--- a/registry/extension/oci/artifactmanifest.go
+++ b/registry/extension/oci/artifactmanifest.go
@@ -53,8 +53,11 @@ func (a Manifest) References() []distribution.Descriptor {
 }
 
 // Subject returns the the subject manifest this artifact references.
-func (a Manifest) Subject() distribution.Descriptor {
-	return distribution.Descriptor{
+func (a Manifest) Subject() *distribution.Descriptor {
+	if a.inner.Subject == nil {
+		return nil
+	}
+	return &distribution.Descriptor{
 		MediaType: a.inner.Subject.MediaType,
 		Digest:    a.inner.Subject.Digest,
 		Size:      a.inner.Subject.Size,

--- a/registry/extension/oci/artifactmanifesthandler.go
+++ b/registry/extension/oci/artifactmanifesthandler.go
@@ -100,12 +100,13 @@ func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm Deser
 		}
 
 		// Validate subject manifest.
-		subject := dm.Subject()
-		exists, err := ms.Exists(ctx, subject.Digest)
-		if !exists || err == distribution.ErrBlobUnknown {
-			errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: subject.Digest})
-		} else if err != nil {
-			errs = append(errs, err)
+		if subject := dm.Subject(); subject != nil {
+			exists, err := ms.Exists(ctx, subject.Digest)
+			if !exists || err == distribution.ErrBlobUnknown {
+				errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: subject.Digest})
+			} else if err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 
@@ -121,7 +122,11 @@ func (amh *artifactManifestHandler) indexReferrers(ctx context.Context, dm Deser
 	// [TODO] We can use artifact type in the link path to support filtering by artifact type
 	//  but need to consider the max path length in different os
 	//artifactType := dm.ArtifactType()
-	subjectRevision := dm.Subject().Digest
+	subject := dm.Subject()
+	if subject == nil {
+		return nil
+	}
+	subjectRevision := subject.Digest
 
 	rootPath := path.Join(referrersLinkPath(amh.repository.Named().Name()), subjectRevision.Algorithm().String(), subjectRevision.Hex())
 	referenceLinkPath := path.Join(rootPath, revision.Algorithm().String(), revision.Hex(), "link")


### PR DESCRIPTION
Fix bug found by @Wwwsylvia that the server will return 500 errors if the pushed artifact manifest has no subject.